### PR TITLE
Create appinstancegroup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 __pycache__
 __pycache__/*
 *.retry
+ngnix-with-lb-maintainer.pem

--- a/ansible/create.yml
+++ b/ansible/create.yml
@@ -8,3 +8,4 @@
     - { role: network }
     - { role: buckets }
     - { role: security }
+    - { role: appinstancegroup }

--- a/ansible/group_vars/all/configuration.yml
+++ b/ansible/group_vars/all/configuration.yml
@@ -10,6 +10,15 @@ tag_prefix: "ngnix-lb-example"
 stage_access_name: "{{tag_prefix}}-{{stage}}"
 iam_role: "{{stage_access_name}}"
 
+# AMI used for server instances both golang and nginx by region
+# Adopting Amazon Linux as suitable basis: CentOS 7 (x86_64) - with Updates HVM Dec 2017
+image_to_launch:
+  eu-west-1: "ami-5f76b626"
+  eu-west-2: "ami-951201f1"
+  eu-central-1: "ami-2540f74a"
+  us-west-1: "ami-db48ada1"
+  # etc
+
 # Public DNS
 public_dns_root_domain: "ngnix-lb-example.consecutive-operations.co.uk"
 

--- a/ansible/roles/appinstancegroup/tasks/create.yml
+++ b/ansible/roles/appinstancegroup/tasks/create.yml
@@ -1,0 +1,17 @@
+- name: launch app instance group for {{stage_access_name}} 
+  cloudformation:
+    profile: "{{aws_account_profile}}"
+    stack_name: "{{stage_access_name}}-app-instances"
+    state: "present"
+    region: "{{aws_region}}"
+    disable_rollback: true
+    template: "./roles/appinstancegroup/templates/appinstancegroup.template"
+    template_parameters:
+      AmazonImageId: "ami-7abd0209"
+      PrivateSubnets: "{{network_private_subnets}}"
+      InstanceType: "t2.micro"
+      VPC: "{{network_vpc}}"
+      IngressSecurityCIDRRange: "{{network_cidr_for_vpc}}"   # TODO - Lock down tighter to eligible SGs
+      Stage: "{{stage}}"
+      DesiredInstanceCount: 2
+  register: appinstancegroup_results

--- a/ansible/roles/appinstancegroup/tasks/create.yml
+++ b/ansible/roles/appinstancegroup/tasks/create.yml
@@ -7,7 +7,7 @@
     disable_rollback: true
     template: "./roles/appinstancegroup/templates/appinstancegroup.template"
     template_parameters:
-      AmazonImageId: "ami-7abd0209"
+      AmazonImageId: "{{image_to_launch[aws_region]}}"
       PrivateSubnets: "{{network_private_subnets}}"
       InstanceType: "t2.micro"
       VPC: "{{network_vpc}}"

--- a/ansible/roles/appinstancegroup/tasks/destroy.yml
+++ b/ansible/roles/appinstancegroup/tasks/destroy.yml
@@ -1,0 +1,8 @@
+- name: destroy network cfn stack for {{stage_access_name}}
+  cloudformation:
+    profile: "{{aws_account_profile}}"
+    stack_name: "{{stage_access_name}}-app-instances"
+    state: "absent"
+    region: "{{aws_region}}"
+    disable_rollback: True
+  ignore_errors: True

--- a/ansible/roles/appinstancegroup/tasks/main.yml
+++ b/ansible/roles/appinstancegroup/tasks/main.yml
@@ -1,0 +1,9 @@
+# - include: upload_app_configuration.yml
+#  when: stack_state == "present"
+# TODO - When there is time create the up to date configuration to upload e.g. to s3
+
+- import_tasks: create.yml
+  when: stack_state == "present"
+
+- import_tasks: destroy.yml
+  when: stack_state == "absent"

--- a/ansible/roles/appinstancegroup/templates/appinstancegroup.template
+++ b/ansible/roles/appinstancegroup/templates/appinstancegroup.template
@@ -8,7 +8,6 @@
     "AmazonImageId": {
       "Type": "String",
       "Description": "The id of the AMI used to create each application instance",
-      "Default": "ami-5f76b626",
       "AllowedPattern": "ami-[a-z0-9]*",
       "MinLength": "12",
       "ConstraintDescription": "Must be the id of an AMI available to this account"

--- a/ansible/roles/appinstancegroup/templates/appinstancegroup.template
+++ b/ansible/roles/appinstancegroup/templates/appinstancegroup.template
@@ -1,0 +1,166 @@
+{ "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "Create group of application instances in private subnets equipped to run golang application",
+  "Parameters": {
+    "KeyPairName": {
+      "Type": "AWS::EC2::KeyPair::KeyName",
+      "Default": "ngnix-with-lb-maintainer"
+    },
+    "AmazonImageId": {
+      "Type": "String",
+      "Description": "The id of the AMI used to create each application instance",
+      "Default": "ami-5f76b626",
+      "AllowedPattern": "ami-[a-z0-9]*",
+      "MinLength": "12",
+      "ConstraintDescription": "Must be the id of an AMI available to this account"
+    },
+    "PrivateSubnets": {
+      "Type": "CommaDelimitedList",
+      "Description": "List of subnets in the VPC to which application instances may reside",
+      "ConstraintDescription": "Requires list of subnets"
+    },
+    "InstanceType": {
+      "Description": "EC2 instance type for each application instance",
+      "Type": "String",
+      "Default": "t2.micro",
+      "AllowedValues": [
+        "t2.micro",
+        "t2.small",
+        "t2.medium",
+        "t2.large",
+        "m4.large",
+        "m4.xlarge",
+        "m4.2xlarge",
+        "m3.medium",
+        "m3.large",
+        "m3.xlarge",
+        "c4.large",
+        "c4.xlarge",
+        "c4.2xlarge"
+      ],
+      "ConstraintDescription": "Current EC2 m type of capacity from 1 vCPU up to 8 vCPU"
+    },
+    "VPC": {
+      "Type": "String",
+      "Description": "VPC in which security groups are defined",
+      "MinLength": "12",
+      "AllowedPattern": "vpc-[a-z0-9]*",
+      "ConstraintDescription": "Must be a vpc identifier"
+    },
+    "IngressSecurityCIDRRange": {
+      "Description": "Range to restrict the security group to",
+      "Type": "String"
+    },
+    "Stage": {
+      "Description": "Stage",
+      "Type": "String"
+    },
+    "DesiredInstanceCount": {
+      "Description": "The positive number of app instances required in this group",
+      "Type": "Number",
+      "ConstraintDescription": "positive"
+    }
+  },
+  "Resources": {
+    "ApplicationInstanceASG": {
+      "Type": "AWS::AutoScaling::AutoScalingGroup",
+      "Properties": {
+        "VPCZoneIdentifier": {
+          "Ref": "PrivateSubnets"
+        },
+        "LaunchConfigurationName": {
+          "Ref": "ApplicationInstanceLaunchConfig"
+        },
+        "MinSize": "1",
+        "MaxSize": { "Ref": "DesiredInstanceCount" },
+        "DesiredCapacity": { "Ref": "DesiredInstanceCount" },
+        "Tags": [{
+          "Key": "Name",
+          "PropagateAtLaunch": "true",
+          "Value": {
+            "Fn::Join": [
+              "-", [{
+                  "Ref": "AWS::StackName"
+                },
+                "instance"
+              ]
+            ]
+          }
+        }]
+      }
+    },
+    "SecurityGroupAppInstance": {
+      "Type": "AWS::EC2::SecurityGroup",
+      "Properties": {
+        "GroupDescription": "Enable ssh login for a private instance",
+        "VpcId": {
+          "Ref": "VPC"
+        },
+        "SecurityGroupIngress": [{
+            "IpProtocol": "tcp",
+            "FromPort": "22",
+            "ToPort": "22",
+            "CidrIp": {
+              "Ref": "IngressSecurityCIDRRange"
+            }
+          },
+          {
+            "IpProtocol": "tcp",
+            "FromPort": "8484",
+            "ToPort": "8484",
+            "CidrIp": {
+              "Ref": "IngressSecurityCIDRRange"
+            }
+          }
+        ],
+        "Tags": [{
+          "Key": "Name",
+          "Value": "app-access"
+        }]
+      }
+    },
+    "ApplicationInstanceLaunchConfig": {
+      "Type": "AWS::AutoScaling::LaunchConfiguration",
+      "Properties": {
+        "ImageId": {
+          "Ref": "AmazonImageId"
+        },
+        "KeyName": {
+          "Ref": "KeyPairName"
+        },
+        "SecurityGroups": [{
+          "Ref": "SecurityGroupAppInstance"
+        }],
+        "InstanceType": {
+          "Ref": "InstanceType"
+        },
+
+        "AssociatePublicIpAddress": "false",
+        "UserData": {
+          "Fn::Base64": {
+            "Fn::Join": [
+              "\n", [
+                "#!/bin/bash -e",
+                "/bin/echo '#!/bin/bash' > /etc/profile.d/host-instance-customizations.sh"
+              ]
+            ]
+          }
+        }
+      }
+    }
+
+  },
+  "Outputs": {
+    "ApplicationInstancesAutoScalingGroupId": {
+      "Value": {
+        "Ref": "ApplicationInstanceASG"
+      },
+      "Description": "Auto-scaling-group id for application instance"
+    },
+    "AmazonImageId": {
+      "Value": {
+        "Ref": "AmazonImageId"
+      },
+      "Description": "Amazon image id for application instance"
+    }
+  }
+}

--- a/ansible/roles/appinstancegroup/templates/appinstancegroup.template
+++ b/ansible/roles/appinstancegroup/templates/appinstancegroup.template
@@ -161,6 +161,10 @@
         "Ref": "AmazonImageId"
       },
       "Description": "Amazon image id for application instance"
+    },
+    "Stage": {
+      "Description": "The name of this stage",
+      "Value": { "Ref": "Stage" }
     }
   }
 }

--- a/ansible/roles/network/tasks/create.yml
+++ b/ansible/roles/network/tasks/create.yml
@@ -37,3 +37,10 @@
 #  delegate_to: localhost
 #  changed_when: False
 
+- name: set variables network_vpc network_cidr_for_vpc network_public_subnets network_private_subnets
+  set_fact:
+    network_vpc="{{cfn_network_results.stack_outputs.VPC}}"
+    network_cidr_for_vpc="{{cfn_network_results.stack_outputs.VPCCidr}}"
+    network_public_subnets="{{cfn_network_results.stack_outputs.PublicSubnets}}"
+    network_private_subnets="{{cfn_network_results.stack_outputs.PrivateSubnets}}"
+  changed_when: False


### PR DESCRIPTION
Ensure that the ASG for app instances are created in the appropriate region for the stage under test.

2 suitable instances of an up to date Amazon Linux (HVM) are launched. There is no application deployment in this PR and the stub entry for UserData is left crudely in place. Although this latter is crude it should not prevent further solution elaboration at this step.